### PR TITLE
Inline sample PDF fixture for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ This web application converts multi-page bank statement PDFs into structured Exc
 - Ensure Tesseract is correctly installed and available in your system PATH. Adjust `pytesseract.pytesseract.tesseract_cmd` in `app.py` if necessary.
 - For larger PDFs (up to ~50 pages), processing time may vary depending on your hardware.
 
+
+## Testing
+
+Unit tests build a tiny PDF from a base64 string to avoid storing binary fixtures in the repository. To update the embedded fixture, encode a PDF file and replace the value in `tests/test_process_pdf.py`:
+
+```bash
+python - <<'PY'
+import base64, pathlib
+pdf_bytes = pathlib.Path('sample.pdf').read_bytes()
+print(base64.b64encode(pdf_bytes).decode())
+PY
+```

--- a/tests/test_process_pdf.py
+++ b/tests/test_process_pdf.py
@@ -1,0 +1,44 @@
+import base64
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from pathlib import Path
+from PIL import Image
+from app import process_pdf, app as flask_app
+
+# Base64-encoded minimal PDF used for tests.
+# To regenerate PDF_BASE64, run:
+#   python - <<'END'
+#   import base64, pathlib
+#   pdf_bytes = b"%PDF-1.1\n%\xe2\xe3\xcf\xd3\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Count 0/Kids[]>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF"
+#   pathlib.Path('sample.pdf').write_bytes(pdf_bytes)
+#   print(base64.b64encode(pdf_bytes).decode())
+#   END
+
+PDF_BASE64 = (
+    "JVBERi0xLjEKJeLjz9MKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0NvdW50IDAvS2lkc1tdPj5lbmRvYmoKdHJhaWxlcjw8L1Jvb3QgMSAwIFI+PgolJUVPRg=="
+)
+
+
+def _write_sample_pdf(tmp_path: Path) -> Path:
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(base64.b64decode(PDF_BASE64))
+    return pdf_path
+
+
+def test_process_pdf(monkeypatch, tmp_path):
+    pdf_file = _write_sample_pdf(tmp_path)
+
+    def fake_convert_from_path(path, fmt="jpeg", output_folder=None):
+        img = Image.new("RGB", (10, 10), color="white")
+        return [img]
+
+    def fake_image_to_string(img):
+        return "01/01/2020 Test 1.00 2.00 3.00"
+
+    monkeypatch.setattr("app.convert_from_path", fake_convert_from_path)
+    monkeypatch.setattr("app.pytesseract.image_to_string", fake_image_to_string)
+
+    flask_app.config["OUTPUT_FOLDER"] = str(tmp_path)
+    excel_name = process_pdf(str(pdf_file))
+    assert (tmp_path / excel_name).exists()


### PR DESCRIPTION
## Summary
- replace sample PDF fixture with embedded base64 data
- document how to regenerate the test fixture
- add regression test for `process_pdf`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68963f28e7d08326987a30eb88a5198f